### PR TITLE
docs(pencil): TAHUB-13 ✏️ update README and tweaked warnings

### DIFF
--- a/.github/scripts/upload-preview-artifact.sh
+++ b/.github/scripts/upload-preview-artifact.sh
@@ -46,4 +46,4 @@ az storage blob copy start \
   --auth-mode login
 
 echo "Artifact upload complete"
-echo "::set-output name=download_url::https://${STORAGE_ACCOUNT}.blob.core.windows.net/builds/${ENV_NAME}/taskhub-latest.zip"
+echo "{download_url}={https://${STORAGE_ACCOUNT}.blob.core.windows.net/builds/${ENV_NAME}/taskhub-latest.zip}"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -102,6 +102,6 @@ jobs:
         if: success()
         run: |
           echo "🚀 Successfully deployed to ${{ github.event.inputs.environment }} environment"
-          echo "URL: https://wonderful-stone-059600500-${{ github.event.inputs.environment }}.eastasia.6.azurestaticapps.net"
+          echo "URL: https://polite-cliff-035266300-${{ github.event.inputs.environment }}.eastasia.6.azurestaticapps.net"
           echo "Build artifact: taskhub-${{ github.event.inputs.environment }}-${{ steps.create_artifact.outputs.timestamp }}.zip stored in Azure Blob Storage"
           echo "Download link: ${{ steps.upload_artifact.outputs.download_url }}"

--- a/README.md
+++ b/README.md
@@ -25,19 +25,18 @@ TaskHub-app uses a robust CI/CD pipeline with GitHub Actions that includes:
 1. **Build Artifacts Storage**
 
    - Every build is archived in Azure Blob Storage with appropriate versioning
-   - Production builds include semantic version numbers in filenames
+   - Production builds include semantic version numbers in filenames and are retained for 3 months
+   - Preview builds are retained for 9 days
    - GitHub Actions artifacts are also available for download
    - Latest builds for each environment are specially tagged
 
 2. **Environment Deployments**
 
-   - **Development**: Automatic deployment when code is merged to `develop`
    - **Preview**: Manual deployment for feature testing
-   - **Production**: Automatic deployment with semantic versioning when code is merged to `main`. Final PR for version bump which needs to be merged manually
+   - **Production**: Automatic deployment with semantic versioning when code is merged to `main`
 
 3. **Build Access**
    - Production builds: `https://<storage-account>.blob.core.windows.net/builds/production/taskhub-latest.zip`
-   - Development builds: `https://<storage-account>.blob.core.windows.net/builds/dev/taskhub-latest.zip`
    - Preview builds: `https://<storage-account>.blob.core.windows.net/builds/<preview-env>/taskhub-latest.zip`
    - Historical builds with timestamps are also preserved
 
@@ -67,9 +66,8 @@ volta install node@22.14.0 pnpm@10.6.3
 ## Links to Environments
 
 1. **[Development](https://green-grass-07a60cd00.6.azurestaticapps.net)**
-2. **[Preview Environment 1](https://wonderful-stone-059600500-preview1.eastasia.6.azurestaticapps.net)**
-3. **[Preview Environment 2](https://wonderful-stone-059600500-preview2.eastasia.6.azurestaticapps.net/)**
-4. **[Production](https://kind-water-0ea27f900.6.azurestaticapps.net)**
+2. **[Preview Environment 1](https://polite-cliff-035266300-preview1.eastasia.6.azurestaticapps.net)**
+3. **[Preview Environment 2](https://polite-cliff-035266300-preview2.eastasia.6.azurestaticapps.net)**
 
 ## License
 


### PR DESCRIPTION
# Description

- [ ] Removed `set-output` warning. The bug can be [found here.](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- [ ] Tweaked the urls for preview deployment in the workflow files.
- [ ] Updated the `README.md` file to factor in the url links and the retention period inside of blob storage.

Fixes # (issue) **Not Applicable**

## Type of change

- [ ] This change requires a documentation update

## How Has This Been Tested?

The change has been thoroughly tested by running the pipeline and the run is successful.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
